### PR TITLE
Allow using remote URL for ollama provider

### DIFF
--- a/backend/config/config.py
+++ b/backend/config/config.py
@@ -1,3 +1,3 @@
-MODEL="gpt-4o" # gpt-4o or gemma2 for example
-PROVIDER="openai" # use openai or ollama
-HOST="" # not supported for OllamaEmbeddings in LangChain yet
+MODEL="gemma2" # gpt-4o or gemma2 for example
+PROVIDER="ollama" # use openai or ollama
+HOST="http://192.168.1.60:1143" # API URL for ollama if not localhost

--- a/backend/config/config.py
+++ b/backend/config/config.py
@@ -1,3 +1,3 @@
-MODEL="gemma2" # gpt-4o or gemma2 for example
-PROVIDER="ollama" # use openai or ollama
-HOST="http://192.168.1.60:1143" # API URL for ollama if not localhost
+MODEL="gpt-4o" # gpt-4o or gemma2 for example
+PROVIDER="openai" # use openai or ollama
+HOST="http://192.168.1.60:11434" # API URL for ollama if not using default localhost route, else leave empty

--- a/backend/src/rag.py
+++ b/backend/src/rag.py
@@ -47,7 +47,8 @@ def get_embedding():
         return OpenAIEmbeddings()
     elif PROVIDER == "ollama":
         return OllamaEmbeddings(
-            model="nomic-embed-text"
+            model="nomic-embed-text",
+            base_url=HOST
         )
     else:
         raise ValueError(f"Invalid provider {PROVIDER}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 langchain==0.2.12
 langchain-core==0.2.29
 langchain-openai==0.1.21
-langchain-ollama==0.1.1
+langchain-ollama==0.1.2
 langchain-chroma==0.1.2
 langchain-community==0.2.7
 langchain-unstructured==0.1.1


### PR DESCRIPTION
Langchain-ollama finally released a fix yesterday allowing to use custom URL for embeddings, I've checked using a local computer and another through a VPN, no problem so far.

To update langchain-ollama, use the following command :
`python3 -m pip install langchain-ollama -U`